### PR TITLE
Update run-command dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3795,12 +3795,12 @@
             "dev": true
         },
         "run-command": {
-            "version": "github:matlab-actions/run-command#ebd7ab949bcce9116a6cd1ba4883a1987b8cefbe",
-            "from": "github:matlab-actions/run-command#v0.1.1",
+            "version": "github:matlab-actions/run-command#bb9154d700c46142c6fb6d1f8f42702622adfaa1",
+            "from": "github:matlab-actions/run-command#v0.2.1",
             "requires": {
                 "@actions/core": "^1.2.6",
                 "@actions/exec": "^1.0.4",
-                "uuid": "^8.3.0"
+                "uuid": "^8.3.1"
             }
         },
         "safe-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "run-matlab-tests-action",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.4",
-        "run-command": "github:matlab-actions/run-command#v0.1.1"
+        "run-command": "github:matlab-actions/run-command#v0.2.1"
     },
     "devDependencies": {
         "@types/jest": "^26.0.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "run-matlab-tests-action",
     "author": "The MathWorks, Inc.",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "",
     "main": "lib/index.js",
     "scripts": {


### PR DESCRIPTION
The primary goal of this PR is to remove the duplicate headers that appear in the log. Because run-command is used as a dependency, its contents is evaluated at runtime when `required` by Node. Therefore, a guard had to be added in run-command to stop it from running when included by another module (such as run-tests).

Before:
![image](https://user-images.githubusercontent.com/2079700/101505641-90821100-3942-11eb-8f6f-9e3b857d7f33.png)

After
![image](https://user-images.githubusercontent.com/2079700/101505523-75170600-3942-11eb-8c16-ea12677a4fd5.png)