### PR TITLE
Attempt to fix releases by configuring run-command separately

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: webfactory/ssh-agent@v0.5.2
+        name: Configure SSH+Git
         with:
           ssh-private-key: |
             ${{ secrets.RUN_COMMAND_KEY }}

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: webfactory/ssh-agent@v0.5.2
-        name: Configure SSH+Git
+      - name: Configure run-command
+        uses: webfactory/ssh-agent@v0.5.2
         with:
           ssh-private-key: |
             ${{ secrets.RUN_COMMAND_KEY }}

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -6,15 +6,12 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      # Need to do some special git configuration after checking out
-      # https://github.com/actions/setup-node/issues/214
       - uses: actions/checkout@v2
+
+      - uses: webfactory/ssh-agent@v0.5.2
         with:
-          persist-credentials: false
-      - name: Use HTTPS instead of SSH for git auth
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
+          ssh-private-key: |
+            ${{ secrets.RUN_COMMAND_KEY }}
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure run-command
+        uses: webfactory/ssh-agent@v0.5.2
+        with:
+          ssh-private-key: |
+            ${{ secrets.RUN_COMMAND_KEY }}
+
       - name: Configure git
         run: |
           git config user.name 'Release Action'


### PR DESCRIPTION
Okay so this repo currently can't release because of the issue mentioned in the previous PR. Basically we can't get `run-command` down via npm/git with just the default git credentials. Since we're only downloading `run-command` as a dependency, we can use a deploy key between the two repos 🤔 