### PR TITLE
Format and shorten action.yml description for marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,8 +28,7 @@ inputs:
     default: ""
   test-results-junit:
     description: >-
-      JUnit-style test results path to write test results report in JUnit XML
-      format
+      Path to write test results report in JUnit XML format
     required: false
     default: ""
   test-results-simulink-test:
@@ -39,8 +38,7 @@ inputs:
     default: ""
   code-coverage-cobertura:
     description: >-
-      Cobertura code coverage Path to write code coverage report in Cobertura
-      XML format
+      Path to write code coverage report in Cobertura XML format
     required: false
     default: ""
   model-coverage-cobertura:

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,8 @@
 # Copyright 2020 The MathWorks, Inc.
 
-name: Run MATLAB 
-Tests description: >-
-  Run all tests in a MATLAB project and generate test artifacts. MATLAB includes
-  any files in your project that have a Test label. If your pipeline does not
-  leverage a MATLAB project, then MATLAB includes all tests in the the root of
-  your repository including its subfolders.
+name: Run MATLAB Tests
+description: >-
+  Run all tests in a MATLAB project and generate test artifacts
 inputs:
   source-folder:
     description: >-
@@ -15,7 +12,7 @@ inputs:
       report, MATLAB uses only the source code in the specified folder and its
       subfolders. You can specify multiple folders using a colon-separated or a
       semicolon-separated list.
-    required: false 
+    required: false
     default: ""
   select-by-folder:
     description: >-
@@ -23,44 +20,44 @@ inputs:
       the project root folder. To create a test suite, MATLAB uses only the
       tests in the specified folders and their subfolders. You can specify
       multiple folders using a colon-separated or semicolon-separated list.
-    required: false 
+    required: false
     default: ""
   select-by-tag:
     description: >-
       Test tag used to select test suite elements. To create a test suite,
       MATLAB uses only the test elements with the specified tag.
-    required: false 
+    required: false
     default: ""
   test-results-pdf:
     description: >-
       Path to write test results report in PDF format (currently not supported
       on macOS platforms).
-    required: false 
+    required: false
     default: ""
   test-results-junit:
     description: >-
       JUnit-style test results Path to write test results report in JUnit XML
       format.
-    required: false 
+    required: false
     default: ""
   test-results-simulink-test:
     description: >-
       Path to export Simulink Test Manager results in MLDATX format (requires
       Simulink Test license and is supported in MATLAB R2019a or later).
-    required: false 
+    required: false
     default: ""
   code-coverage-cobertura:
     description: >-
       Cobertura code coverage Path to write code coverage report in Cobertura
       XML format.
-    required: false 
+    required: false
     default: ""
   model-coverage-cobertura:
     description: >-
       Path to write model coverage report in Cobertura XML format (requires
       Simulink Coverage license and is supported in MATLAB R2018b or later).
-    required: false 
+    required: false
     default: ""
 runs:
-  using: node12 
+  using: node12
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@
 
 name: Run MATLAB Tests
 description: >-
-  Run all tests in a MATLAB project and generate test artifacts
+  Run MATLAB and Simulink tests and generate artifacts
 inputs:
   source-folder:
     description: >-

--- a/action.yml
+++ b/action.yml
@@ -41,8 +41,7 @@ inputs:
     default: ""
   model-coverage-cobertura:
     description: >-
-      Path to write model coverage report in Cobertura XML format (requires
-      MATLAB R2018b or later)
+      Path to write model coverage report in Cobertura XML format
     required: false
     default: ""
 runs:

--- a/action.yml
+++ b/action.yml
@@ -6,56 +6,47 @@ description: >-
 inputs:
   source-folder:
     description: >-
-      Source code folder Location of the folder containing source code, relative
-      to the project root folder. The specified folder and its subfolders are
-      added to the top of the MATLAB search path. To generate a code coverage
-      report, MATLAB uses only the source code in the specified folder and its
-      subfolders. You can specify multiple folders using a colon-separated or a
-      semicolon-separated list.
+      Source code folder location of the folder containing source code
     required: false
     default: ""
   select-by-folder:
     description: >-
       Locations of the folders used to select test suite elements, relative to
-      the project root folder. To create a test suite, MATLAB uses only the
-      tests in the specified folders and their subfolders. You can specify
-      multiple folders using a colon-separated or semicolon-separated list.
+      the project root folder
     required: false
     default: ""
   select-by-tag:
     description: >-
-      Test tag used to select test suite elements. To create a test suite,
-      MATLAB uses only the test elements with the specified tag.
+      Test tag used to select test suite elements
     required: false
     default: ""
   test-results-pdf:
     description: >-
-      Path to write test results report in PDF format (currently not supported
-      on macOS platforms).
+      Path to write test results report in PDF format (not supported
+      on macOS)
     required: false
     default: ""
   test-results-junit:
     description: >-
-      JUnit-style test results Path to write test results report in JUnit XML
-      format.
+      JUnit-style test results path to write test results report in JUnit XML
+      format
     required: false
     default: ""
   test-results-simulink-test:
     description: >-
-      Path to export Simulink Test Manager results in MLDATX format (requires
-      Simulink Test license and is supported in MATLAB R2019a or later).
+      Path to export Simulink Test Manager results in MLDATX format
     required: false
     default: ""
   code-coverage-cobertura:
     description: >-
       Cobertura code coverage Path to write code coverage report in Cobertura
-      XML format.
+      XML format
     required: false
     default: ""
   model-coverage-cobertura:
     description: >-
       Path to write model coverage report in Cobertura XML format (requires
-      Simulink Coverage license and is supported in MATLAB R2018b or later).
+      MATLAB R2018b or later)
     required: false
     default: ""
 runs:

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: ""
   test-results-pdf:
     description: >-
-      Path to write test results report in PDF format (not supported on macOS)
+      Path to write test results report in PDF format
     required: false
     default: ""
   test-results-junit:

--- a/action.yml
+++ b/action.yml
@@ -6,13 +6,12 @@ description: >-
 inputs:
   source-folder:
     description: >-
-      Source code folder location of the folder containing source code
+      Location of the folder containing source code
     required: false
     default: ""
   select-by-folder:
     description: >-
-      Locations of the folders used to select test suite elements, relative to
-      the project root folder
+      Location of the folder containing test files
     required: false
     default: ""
   select-by-tag:
@@ -22,8 +21,7 @@ inputs:
     default: ""
   test-results-pdf:
     description: >-
-      Path to write test results report in PDF format (not supported
-      on macOS)
+      Path to write test results report in PDF format (not supported on macOS)
     required: false
     default: ""
   test-results-junit:


### PR DESCRIPTION
Attempting to get into the marketplace now (woooo 🥳 ). First thing they flag is our descriptions being too long (needs to be < 125 characters). So, I've just grabbed the first sentence since it's straight to the point (the magic is really all @mw-hrastega).

As for the lack of punctuation at the end: that seems to be the trend with other actions 🤔