### PR TITLE
Add a check to see if MATLAB Test toolbox is installed

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -105,7 +105,7 @@ jobs:
           grep "::group::TheTruth" output.log
         shell: bash
   run-test-without-install:
-    name: Run tests without installation 
+    name: Run tests without installation
     needs: bat
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -104,17 +104,17 @@ jobs:
         run: |
           grep "::group::TheTruth" output.log
         shell: bash
-  run-test-without-install:
-    name: Run tests without installation
+  run-tests-without-matlabtest:
+    name: Run tests without MATLAB Test
     needs: bat
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: built-action
-      - name: Perform 'setup-matlab' without MATLAB_Test
-        uses: matlab-actions/setup-matlab@v2
-      - name: Run MATLAB Tests without MATLAB_Test
+      - name: Perform 'setup-matlab' without MATLAB Test
+        uses: matlab-actions/setup-matlab@v3
+      - name: Run MATLAB Tests
         uses: ./
         with:
           source-folder: sample

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -36,7 +36,6 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           products: |
-            MATLAB_Test
             Simulink
             Simulink_Test
             Simulink_Coverage

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -104,8 +104,8 @@ jobs:
         run: |
             grep "::group::TheTruth" output.log
         shell: bash
-  test-without-matlab-test:
-    name: Test Without Installing MATLAB_Test
+  run-test-without-install:
+    name: Run tests without installation 
     needs: bat
     runs-on: ubuntu-latest
     steps:
@@ -114,9 +114,6 @@ jobs:
           name: built-action
       - name: Perform 'setup-matlab' without MATLAB_Test
         uses: matlab-actions/setup-matlab@v2
-        with:
-          products: |
-            Simulink
       - name: Run MATLAB Tests without MATLAB_Test
         uses: ./
         with:

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -36,6 +36,7 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           products: |
+            MATLAB_Test
             Simulink
             Simulink_Test
             Simulink_Coverage

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -104,3 +104,21 @@ jobs:
         run: |
             grep "::group::TheTruth" output.log
         shell: bash
+  test-without-matlab-test:
+    name: Test Without Installing MATLAB_Test
+    needs: bat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: built-action
+      - name: Perform 'setup-matlab' without MATLAB_Test
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          products: |
+            Simulink
+      - name: Run MATLAB Tests without MATLAB_Test
+        uses: ./
+        with:
+          source-folder: sample
+          code-coverage-metric-level: mcdc

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -34,6 +34,11 @@ jobs:
           name: built-action
       - name: Perform 'setup-matlab'
         uses: matlab-actions/setup-matlab@v2
+        with:
+          products: |
+            Simulink
+            Simulink_Test
+            Simulink_Coverage
       - name: Run MATLAB Tests
         continue-on-error: true
         uses: ./

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -34,12 +34,6 @@ jobs:
           name: built-action
       - name: Perform 'setup-matlab'
         uses: matlab-actions/setup-matlab@v2
-        with:
-          products: |
-            MATLAB_Test
-            Simulink
-            Simulink_Test
-            Simulink_Coverage
       - name: Run MATLAB Tests
         continue-on-error: true
         uses: ./

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -4,9 +4,8 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
     methods
         function plugins = providePlugins(~, ~)
 
-            hasTestInstalled = ~isempty(ver('matlab_test'));
-            % Check if MATLAB Test license is available
-            if license('test', 'matlab_test') && hasTestInstalled
+            % Check if matlab_test toolbox is installed and MATLAB Test license is available
+            if  ~isempty(ver('matlab_test')) && license('test', 'matlab_test')
                 
                 % Get metric level from environment variable
                 metricLevel = getenv('INPUT_CODE_COVERAGE_METRIC_LEVEL');

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -3,11 +3,9 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
     
     methods
         function plugins = providePlugins(~, ~)
-
             v = ver;
-            % Check if MATLAB Test license is available and MATLAB Test toolbox is installed
+            % Check if MATLAB Test license is available and MATLAB Test is installed
             if license('test', 'matlab_test') && any(strcmp({v.Name}, 'MATLAB Test'))
-
                 % Get metric level from environment variable
                 metricLevel = getenv('INPUT_CODE_COVERAGE_METRIC_LEVEL');
 

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -9,7 +9,7 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
             disp("MATLAB_Test");
             disp(ver('MATLAB_Test'));
             % Check if matlab_test toolbox is installed and MATLAB Test license is available
-            if  ~isempty(ver('matlab_test')) && license('test', 'matlab_test')
+            if  ~isempty(ver('MATLAB_Test')) && license('test', 'matlab_test')
                 
                 % Get metric level from environment variable
                 metricLevel = getenv('INPUT_CODE_COVERAGE_METRIC_LEVEL');

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -3,9 +3,12 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
     
     methods
         function plugins = providePlugins(~, ~)
-            v = ver;
+            verInfo = ver;
+            productNames = string({verInfo.Name});
+            productName = 'MATLAB Test';
+            isProductInstalled = any(productNames.matches(productName));
             % Check if MATLAB Test license is available and MATLAB Test is installed
-            if license('test', 'matlab_test') && any(strcmp({v.Name}, 'MATLAB Test'))
+            if license('test', 'matlab_test') && isProductInstalled
                 % Get metric level from environment variable
                 metricLevel = getenv('INPUT_CODE_COVERAGE_METRIC_LEVEL');
 

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -4,6 +4,10 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
     methods
         function plugins = providePlugins(~, ~)
 
+            disp("matlab_test");
+            disp(ver('matlab_test'));
+            disp("MATLAB_Test");
+            disp(ver('MATLAB_Test'));
             % Check if matlab_test toolbox is installed and MATLAB Test license is available
             if  ~isempty(ver('matlab_test')) && license('test', 'matlab_test')
                 

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -4,21 +4,10 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
     methods
         function plugins = providePlugins(~, ~)
 
-            disp("matlab_test");
-            disp(ver('matlab_test'));
-            disp("MATLAB_Test");
-            disp(ver('MATLAB_Test'));
-            hasTestInstalled = false;
-            installedProducts = ver;
-            for i = 1:length(installedProducts)
-                if strcmp(installedProducts(i).Name, 'MATLAB Test')
-                    hasTestInstalled = true;
-                    break;
-                end
-            end
-            % Check if matlab_test toolbox is installed and MATLAB Test license is available
-            if  hasTestInstalled && license('test', 'matlab_test')
-                disp("I am here");
+            v = ver;
+            % Check if MATLAB Test license is available and MATLAB Test toolbox is installed
+            if license('test', 'matlab_test') && any(strcmp({v.Name}, 'MATLAB Test'))
+
                 % Get metric level from environment variable
                 metricLevel = getenv('INPUT_CODE_COVERAGE_METRIC_LEVEL');
 

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -4,17 +4,13 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
     methods
         function plugins = providePlugins(~, ~)
 
+            hasTestInstalled = ~isempty(ver('matlab_test'));
             % Check if MATLAB Test license is available
-            if license('test', 'matlab_test') 
+            if license('test', 'matlab_test') && hasTestInstalled
                 
                 % Get metric level from environment variable
                 metricLevel = getenv('INPUT_CODE_COVERAGE_METRIC_LEVEL');
 
-                % Set default metric level if not provided
-                if isempty(metricLevel)
-                    metricLevel = 'mcdc';
-                end
-                
                 % Create a shared CoverageResult format object
                 format = matlab.unittest.plugins.codecoverage.CoverageResult;
                 

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -8,9 +8,17 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
             disp(ver('matlab_test'));
             disp("MATLAB_Test");
             disp(ver('MATLAB_Test'));
+            hasTestInstalled = false;
+            installedProducts = ver;
+            for i = 1:length(installedProducts)
+                if strcmp(installedProducts(i).Name, 'MATLAB Test')
+                    hasTestInstalled = true;
+                    break;
+                end
+            end
             % Check if matlab_test toolbox is installed and MATLAB Test license is available
-            if  ~isempty(ver('MATLAB_Test')) && license('test', 'matlab_test')
-                
+            if  hasTestInstalled && license('test', 'matlab_test')
+                disp("I am here");
                 % Get metric level from environment variable
                 metricLevel = getenv('INPUT_CODE_COVERAGE_METRIC_LEVEL');
 

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -9,6 +9,11 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
                 
                 % Get metric level from environment variable
                 metricLevel = getenv('INPUT_CODE_COVERAGE_METRIC_LEVEL');
+
+                % Set default metric level if not provided
+                if isempty(metricLevel)
+                    metricLevel = 'mcdc';
+                end
                 
                 % Create a shared CoverageResult format object
                 format = matlab.unittest.plugins.codecoverage.CoverageResult;


### PR DESCRIPTION
In my previous PR https://github.com/matlab-actions/run-tests/pull/77 , I missed to check if the user has installed MATLAB Test toolbox or not because of which there were failures recorded. I have fixed it in this PR by adding a check for the same. 