### PR TITLE
Limit MATLAB Test product installation check to decision, condition, and mcdc metric levels

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -121,12 +121,17 @@ jobs:
         with:
           source-folder: sample
           code-coverage-metric-level: mcdc
+      - name: Run MATLAB Tests for statement coverage without MATLAB Test # Test Case 2: Statement coverage without MATLAB Test, view is shown
+        uses: ./
+        with:
+          source-folder: sample
+          code-coverage-metric-level: statement
       - name: Perform 'setup-matlab' with MATLAB Test
         uses: matlab-actions/setup-matlab@v3
         with:
           products: |
             MATLAB_Test
-      - name: Run MATLAB Tests with other options # Test Case 2: With MATLAB Test, and other code-coverage options, no view is shown.
+      - name: Run MATLAB Tests with other options # Test Case 3: With MATLAB Test, and other code-coverage options, no view is shown.
         uses: ./
         with:
           model-coverage-cobertura: test-results/modelcoverage.xml
@@ -142,7 +147,7 @@ jobs:
           use-parallel: true
           output-detail: Detailed
           logging-level: Detailed
-      - name: Run MATLAB Tests # Test Case 3: With MATLAB Test, and only code-coverage-metric-level option, view is shown.
+      - name: Run MATLAB Tests # Test Case 4: With MATLAB Test, and only code-coverage-metric-level option, view is shown.
         uses: ./
         with:
           source-folder: sample

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/CodeCoverageSummaryPluginService.m
@@ -3,18 +3,22 @@ classdef CodeCoverageSummaryPluginService < matlab.buildtool.internal.services.c
     
     methods
         function plugins = providePlugins(~, ~)
-            verInfo = ver;
-            productNames = string({verInfo.Name});
-            productName = 'MATLAB Test';
-            isProductInstalled = any(productNames.matches(productName));
             hasCoverageHTML = ~isempty(getenv('MW_INPUT_CODE_COVERAGE_HTML'));
             hasCoverageCobertura = ~isempty(getenv('MW_INPUT_CODE_COVERAGE_COBERTURA'));
             hasCoverageRequest = hasCoverageHTML || hasCoverageCobertura;
+            metricLevel = getenv('MW_INPUT_CODE_COVERAGE_METRIC_LEVEL');
 
-            % Check if MATLAB Test license is available and MATLAB Test is installed
+            % MATLAB Test product installation is only required for decision, condition, and mcdc levels
+            requiresProductInstall = ismember(metricLevel, {'decision', 'condition', 'mcdc'});
+            if requiresProductInstall
+                verInfo = ver;
+                productNames = string({verInfo.Name});
+                isProductInstalled = any(productNames.matches('MATLAB Test'));
+            else
+                isProductInstalled = true;
+            end
+
             if strcmpi(getenv("MW_INPUT_GENERATE_SUMMARY"), "true") && ~hasCoverageRequest && license('test', 'matlab_test') && isProductInstalled
-                % Get metric level from environment variable
-                metricLevel = getenv('MW_INPUT_CODE_COVERAGE_METRIC_LEVEL');
 
                 % Create a shared CoverageResult format object
                 format = matlab.unittest.plugins.codecoverage.CoverageResult;


### PR DESCRIPTION
### Summary
- The MATLAB Test product installation check in `CodeCoverageSummaryPluginService` is now only performed for `decision`, `condition`, and `mcdc` metric levels.
- For `statement` and `function` metric levels, coverage summary generation no longer requires the MATLAB Test product to be installed.
- The `license('test', 'matlab_test')` check continues to apply for all metric levels.