### PR TITLE
Skip floating version tags for prereleases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,12 @@ jobs:
           VERSION=$(npm version "${{ github.event.release.tag_name }}" --no-git-tag-version)
           git add package.json package-lock.json
           git commit -m "[skip ci] Bump $VERSION"
-          git push origin HEAD:main
+          # Skip pushing the version bump to main for prereleases so that
+          # main stays on the last stable version and future npm version
+          # calls don't fail due to semver ordering (e.g. 3.3.1 < 3.4.0-rc.1).
+          if [[ "${{ github.event.release.prerelease }}" != "true" ]]; then
+            git push origin HEAD:main
+          fi
 
       # Now carry on, business as usual
       - name: Perform npm tasks
@@ -66,8 +71,8 @@ jobs:
           # Strip any semver prerelease suffix (e.g. v3.3.0-rc.1 -> v3.3.0)
           # before deriving the floating major/minor tags.
           baseVersion="${longVersion%%-*}"
-          majorVersion=$(echo ${baseVersion%.*.*})
-          minorVersion=$(echo ${baseVersion%.*})
+          majorVersion="${baseVersion%.*.*}"
+          minorVersion="${baseVersion%.*}"
 
           # Add the built artifacts. Using --force because dist/lib should be in
           # .gitignore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,8 +62,12 @@ jobs:
           longVersion="${{github.event.release.tag_name}}"
           echo "Preparing release for version $longVersion"
           [[ $longVersion == v[0-9]*.[0-9]*.[0-9]* ]]  || (echo "must follow semantic versioning" && exit 1)
-          majorVersion=$(echo ${longVersion%.*.*})
-          minorVersion=$(echo ${longVersion%.*})
+
+          # Strip any semver prerelease suffix (e.g. v3.3.0-rc.1 -> v3.3.0)
+          # before deriving the floating major/minor tags.
+          baseVersion="${longVersion%%-*}"
+          majorVersion=$(echo ${baseVersion%.*.*})
+          minorVersion=$(echo ${baseVersion%.*})
 
           # Add the built artifacts. Using --force because dist/lib should be in
           # .gitignore
@@ -74,19 +78,25 @@ jobs:
           git commit --allow-empty -m "$MESSAGE"
           git tag -f -a -m "Release $longVersion" $longVersion
 
-          # Get the commit of the tag you just released
-          commitHash=$(git rev-list -n 1 $longVersion)
-
-          # Delete the old major and minor version tags locally
-          git tag -d $majorVersion || true
-          git tag -d $minorVersion || true
-
-          # Make new major and minor version tags locally that point to the commit you got from the "git rev-list" above
-          git tag -f $majorVersion $commitHash
-          git tag -f $minorVersion $commitHash
-
-          # Force push the new minor version tag to overwrite the old tag remotely
-          echo "Pushing new tags"
+          # Always push the exact release tag
+          echo "Pushing exact release tag $longVersion"
           git push -f origin $longVersion
-          git push -f origin $majorVersion
-          git push -f origin $minorVersion
+
+          # Floating major/minor tags (e.g. v3, v3.3) should always point to the
+          # latest stable release. Skip updating them for prereleases so that
+          # users on @v3 are not moved to a prerelease version.
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo "Prerelease detected — skipping update of floating tags $majorVersion and $minorVersion"
+          else
+            commitHash=$(git rev-list -n 1 $longVersion)
+
+            git tag -d $majorVersion || true
+            git tag -d $minorVersion || true
+
+            git tag -f $majorVersion $commitHash
+            git tag -f $minorVersion $commitHash
+
+            echo "Pushing floating tags"
+            git push -f origin $majorVersion
+            git push -f origin $minorVersion
+          fi

--- a/devel/contributing.md
+++ b/devel/contributing.md
@@ -14,6 +14,8 @@ Changes should be made on a new branch. The new branch should be merged to the m
 
 After the pull request has been approved and merged to main, follow the Github process for [creating a new release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository). The release must follow semantic versioning (ex: vX.Y.Z). This will kick off a new pipeline execution, and the action will automatically be published to the GitHub Actions Marketplace if the pipeline finishes successfully. Check the [GitHub Marketplace](https://github.com/marketplace/actions/run-matlab-tests) and check the major version in the repository (ex: v1 for v1.0.0) to ensure that the new semantically versioned tag is available.
 
+For prereleases, use a semver prerelease tag (e.g. `v3.3.0-rc.1`, `v3.3.0-beta.1`) and mark the GitHub Release as a **prerelease**. This skips updating the floating major and minor tags (e.g. `v3`, `v3.3`) so that users on `@v3` stay on the latest stable release. Avoid using a bare version like `v3.3.0` for a prerelease — the workflow will respect the prerelease flag and skip the floating tags, but the tag name itself creates a problem: when you're ready to publish the stable release, `v3.3.0` is already taken, so you'd have to delete and recreate the release rather than simply publishing a new one.
+
 ## Adding a Pre-Commit Hook
 
 You can run all CI checks before each commit by adding a pre-commit hook. To do so, navigate to the repository root folder and run the following commands:


### PR DESCRIPTION
Prereleases no longer move the v3 / v3.3 floating tags, so Dependabot won't bump users on v3 to an RC. The exact tag (e.g. v3.3.0-rc.1) still gets pushed as before. Also fixed the version parsing to handle semver prerelease suffixes - the old ${longVersion%.*} approach breaks on hyphens, so we now strip the prerelease suffix before deriving major/minor.
